### PR TITLE
Add Grimoire and remove duplicate CrossClj

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@
   * [clojuredocs](http://clojuredocs.org)
   * [crossclj](http://crossclj.info/)
   * [clojure-doc](http://clojure-doc.org/)
-  * [CrossClj](http://crossclj.info/)
+  * [Grimoire](http://grimoire.arrdem.com/)
   * [The Clojure Toolbox](http://www.clojure-toolbox.com/)
   * [clojure-cookbook](https://github.com/clojure-cookbook/clojure-cookbook)
 


### PR DESCRIPTION
Grimoire has a slightly more modern interface, but more importantly documentation for Clojure 1.6.0.
