### PR TITLE
Add mount and yada

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
   * [Coils](https://github.com/zubairq/coils)
   * [Duct](https://github.com/weavejester/duct)
   * [Pedestal](https://github.com/pedestal/pedestal)
+  * [yada](https://github.com/juxt/yada)
 
 ## Dependency injection
 
@@ -64,7 +65,7 @@
 
   * [Component](https://github.com/stuartsierra/component)
   * [System](https://github.com/danielsz/system)
-  * [Duct](https://github.com/weavejester/duct)
+  * [mount](https://github.com/tolitius/mount)
 
 ## Build Automation and Package management
 
@@ -155,6 +156,7 @@
 
   * [Liberator](http://clojure-liberator.github.io/liberator/)
   * [compojure-api](https://github.com/metosin/compojure-api)
+  * [yada](https://github.com/juxt/yada)
 
 ## Emails
 


### PR DESCRIPTION
In the "Dependency injection" section, added "mount", removed "duct" as it belongs to the "Web Framework" section and uses "Component".

Added "yada" to "Web Framework" and "RESTful API" sections.