### PR TITLE
Add stars count and last pushed date for GitHub repositories

### DIFF
--- a/awesome_clojure_with_repo_info.md
+++ b/awesome_clojure_with_repo_info.md
@@ -1,0 +1,363 @@
+Awesome Clojure [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+===========================================================================================================================================================================
+
+-   [Awesome products in Clojure](#awesome-products-in-clojure)
+    -   [LightTable (IDE)](http://lighttable.com/)
+    -   [Nightcode (IDE)](https://sekao.net/nightcode/)
+    -   [Riemann (Monitoring)](http://riemann.io/)
+    -   [Puppet Server](https://github.com/puppetlabs/puppet-server)
+    -   [PuppetDB](https://github.com/puppetlabs/puppetdb) <span> | ★ 188, pushed 0 days ago | </span>
+    -   [Metabase](https://github.com/metabase/metabase) <span> | ★ 2531, pushed 0 days ago | </span>
+    -   [Avi (vim rewrite)](https://github.com/maitria/avi) <span> | ★ 149, pushed 0 days ago | </span>
+-   [Languages written with Clojure](#languages-written-with-clojure)
+    -   [jank](https://github.com/jeaye/jank) <span> | ★ 25, pushed 3 days ago | </span>
+    -   [lux](https://github.com/LuxLang/lux) <span> | ★ 445, pushed 1 days ago | </span>
+    -   [mal](https://github.com/kanaka/mal/tree/master/clojure)
+-   [Awesome tools in Clojure](#awesome-tools-in-clojure)
+    -   [Web Framework](#web-framework)
+    -   [Dependency injection](#dependency-injection)
+    -   [Build Automation and Package management](#build-automation-and-package-management)
+    -   [Date and Time](#date-and-time)
+    -   [GUI](#gui)
+    -   [Audio](#audio)
+    -   [HTTP](#http)
+    -   [Database](#database)
+    -   [Connection pools](#connection-pools)
+    -   [Structural Migrations](#structural-migrations)
+    -   [Redis](#redis)
+    -   [JSON](#json)
+    -   [ORM and SQL generation](#orm-and-sql-generation)
+    -   [Security](#security)
+    -   [RESTful API](#restful-api)
+    -   [Emails](#emails)
+    -   [HTML Manipulation](#html-manipulation)
+    -   [Data Validation](#data-validation)
+    -   [Type System](#type-system)
+    -   [Pattern Matching](#pattern-matching)
+    -   [Async processing](#async-processing)
+    -   [Monads](#monads)
+    -   [WebSocket](#websocket)
+    -   [Testing](#testing)
+    -   [Code Analysis and Linter](#code-analysis-and-linter)
+    -   [Science and Data Analysis](#science-and-data-analysis)
+    -   [Machine Learning](#machine-learning)
+    -   [Computer Vision](#computer-vision)
+    -   [Natural Language Processing](#natural-language-processing)
+    -   [Editor Plugins](#editor-plugins)
+    -   [Literate Programming](#literate-programming)
+    -   [Miscellaneous](#miscellaneous)
+    -   [Debugging tools](#debugging)
+    -   [CI](#ci)
+-   [Resources](#resources)
+    -   [Guides](#guides)
+    -   [Websites](#websites)
+    -   [Twitter](#twitter)
+    -   [Exercises](#exercises)
+
+Web Framework
+-------------
+
+*Actually don't search rails/django here, but compose them by yourself*
+
+-   [Web Non-Framework](https://github.com/webnf/webnf) <span> | ★ 16, pushed 2 days ago | </span>
+-   [Luminus](http://www.luminusweb.net/)
+-   [Joodo](https://github.com/slagyr/joodoweb) <span> | ★ 3, pushed 784 days ago | </span>
+-   [Coils](https://github.com/zubairq/AppShare) <span> | ★ 235, pushed 0 days ago | </span>
+-   [Duct](https://github.com/weavejester/duct) <span> | ★ 322, pushed 26 days ago | </span>
+-   [Pedestal](https://github.com/pedestal/pedestal) <span> | ★ 1570, pushed 0 days ago | </span>
+-   [Catalysis](https://github.com/metasoarous/catalysis) <span> | ★ 21, pushed 0 days ago | </span>
+-   [yada](https://github.com/juxt/yada) <span> | ★ 244, pushed 0 days ago | </span>
+
+Dependency injection
+--------------------
+
+*Managed lifecycle of stateful objects*
+
+-   [Component](https://github.com/stuartsierra/component) <span> | ★ 1106, pushed 2 days ago | </span>
+-   [System](https://github.com/danielsz/system) <span> | ★ 347, pushed 4 days ago | </span>
+-   [mount](https://github.com/tolitius/mount) <span> | ★ 379, pushed 2 days ago | </span>
+
+Build Automation and Package management
+---------------------------------------
+
+*Libraries for project build automation and package/dependency management.*
+
+-   [Leiningen](https://github.com/technomancy/leiningen) <span> | ★ 4758, pushed 6 days ago | </span>
+-   [Boot](https://github.com/boot-clj/boot) <span> | ★ 928, pushed 7 days ago | </span>
+
+Date and Time
+-------------
+
+*Libraries for working with dates and times.*
+
+-   [clj-time](https://github.com/clj-time/clj-time) <span> | ★ 465, pushed 15 days ago | </span>
+
+GUI
+---
+
+-   [fx-clj](https://github.com/aaronc/fx-clj) <span> | ★ 68, pushed 87 days ago | </span>
+-   [seesaw](https://github.com/daveray/seesaw) <span> | ★ 1037, pushed 57 days ago | </span>
+
+Audio
+-----
+
+-   [Overtone](http://overtone.github.io/)
+-   [Alda](https://github.com/alda-lang/alda) <span> | ★ 2326, pushed 0 days ago | </span>
+
+HTTP
+----
+
+*Libraries for working with HTTP.*
+
+-   [clj-http](https://github.com/dakrone/clj-http) <span> | ★ 888, pushed 2 days ago | </span>
+-   [http-kit](http://www.http-kit.org/)
+-   [ring](https://github.com/ring-clojure/ring) <span> | ★ 1840, pushed 2 days ago | </span>
+
+Database
+--------
+
+*Databases and database client libraries*
+
+-   [Datomic](http://www.datomic.com/)
+-   [clojure.jdbc](https://github.com/funcool/clojure.jdbc) <span> | ★ 63, pushed 9 days ago | </span>
+-   [cravendb](https://github.com/robashton/cravendb) <span> | ★ 45, pushed 847 days ago | </span>
+-   [Mongo](http://clojuremongodb.info/)
+-   [RethinkDB](https://github.com/apa512/clj-rethinkdb) <span> | ★ 135, pushed 0 days ago | </span>
+
+Connection pools
+----------------
+
+*Database connection pools*
+
+-   [hikari-cp](https://github.com/tomekw/hikari-cp) <span> | ★ 106, pushed 48 days ago | </span>
+
+Structural Migrations
+---------------------
+
+*Keeps database and others in sync*
+
+-   [Lobos](https://github.com/budu/lobos) <span> | ★ 258, pushed 204 days ago | </span>
+-   [Ragtime](https://github.com/weavejester/ragtime) <span> | ★ 288, pushed 4 days ago | </span>
+-   [Joplin](https://github.com/juxt/joplin) <span> | ★ 211, pushed 20 days ago | </span>
+-   [Migratus](https://github.com/yogthos/migratus) <span> | ★ 148, pushed 43 days ago | </span>
+-   [Drift](https://github.com/macourtney/drift) <span> | ★ 104, pushed 367 days ago | </span>
+
+Redis
+-----
+
+-   [carmine](https://github.com/ptaoussanis/carmine) <span> | ★ 603, pushed 11 days ago | </span>
+
+JSON
+----
+
+-   [cheshire](https://github.com/dakrone/cheshire) <span> | ★ 773, pushed 8 days ago | </span>
+
+Database Cli
+------------
+
+ORM and SQL generation
+----------------------
+
+*DSL for SQL generation.*
+
+-   [Korma](http://sqlkorma.com/)
+-   [stch-library/sql](https://github.com/stch-library/sql) <span> | ★ 18, pushed 609 days ago | </span>
+-   [sqlingvo](https://github.com/r0man/sqlingvo) <span> | ★ 103, pushed 1 days ago | </span>
+-   [honeysql](https://github.com/jkk/honeysql) <span> | ★ 429, pushed 6 days ago | </span>
+
+Security
+--------
+
+*Authentication, authorization and other security related libraries.*
+
+-   [Buddy](https://github.com/funcool/buddy) <span> | ★ 424, pushed 11 days ago | </span>
+-   [Friend](https://github.com/cemerick/friend) <span> | ★ 1020, pushed 16 days ago | </span>
+-   [bolt](https://github.com/juxt/bolt) <span> | ★ 122, pushed 273 days ago | </span>
+
+RESTful API
+-----------
+
+*Libraries for developing RESTful APIs.*
+
+-   [Liberator](http://clojure-liberator.github.io/liberator/)
+-   [compojure-api](https://github.com/metosin/compojure-api) <span> | ★ 471, pushed 5 days ago | </span>
+-   [yada](https://github.com/juxt/yada)
+
+Emails
+------
+
+-   [postal](https://github.com/drewr/postal) <span> | ★ 326, pushed 47 days ago | </span>
+
+HTML Manipulation
+-----------------
+
+*Libraries for working with HTML.*
+
+-   [Enlive](https://github.com/cgrand/enlive/wiki)
+-   [hiccup](https://github.com/weavejester/hiccup) <span> | ★ 1336, pushed 15 days ago | </span>
+-   [clostache](https://github.com/fhd/clostache) <span> | ★ 252, pushed 194 days ago | </span>
+
+Data Validation
+---------------
+
+*Libraries for validating data.*
+
+-   [Validateur](http://clojurevalidations.info/)
+-   [Prismatic's schema](https://github.com/plumatic/schema) <span> | ★ 1528, pushed 1 days ago | </span>
+-   [domaintypes](https://github.com/friemen/domaintypes) <span> | ★ 5, pushed 513 days ago | </span>
+-   [Bouncer](https://github.com/leonardoborges/bouncer) <span> | ★ 261, pushed 121 days ago | </span>
+-   [clova](https://github.com/markwoodhall/clova) <span> | ★ 5, pushed 32 days ago | </span>
+
+Type System
+-----------
+
+*Optional type system for Clojure*
+
+-   [core.typed](https://github.com/clojure/core.typed) <span> | ★ 823, pushed 4 days ago | </span>
+
+Pattern Matching
+----------------
+
+-   [core.match](https://github.com/clojure/core.match) <span> | ★ 641, pushed 109 days ago | </span>
+-   [Verbal-Exprejon](https://github.com/GuillaumeBadi/Verbal-Exprejon) <span> | ★ 80, pushed 92 days ago | </span>
+-   [defun](https://github.com/killme2008/defun) <span> | ★ 278, pushed 176 days ago | </span>
+
+Async processing
+----------------
+
+-   [core.async](https://github.com/clojure/core.async/)
+-   [pulsar](https://github.com/puniverse/pulsar)
+-   [lamina](https://github.com/ztellman/lamina) <span> | ★ 738, pushed 218 days ago | </span>
+-   [aleph](https://github.com/ztellman/aleph) <span> | ★ 1596, pushed 3 days ago | </span>
+
+Monads
+------
+
+-   [cats](https://github.com/funcool/cats) <span> | ★ 355, pushed 21 days ago | </span>
+-   [algo.monads](https://github.com/clojure/algo.monads) <span> | ★ 279, pushed 109 days ago | </span>
+
+WebSocket
+---------
+
+-   [Sente](https://github.com/ptaoussanis/sente) <span> | ★ 990, pushed 0 days ago | </span>
+
+Testing
+-------
+
+-   [Expectations](http://jayfields.com/expectations/)
+-   [Midje](https://github.com/marick/Midje) <span> | ★ 1179, pushed 8 days ago | </span>
+
+Code Analysis and Linter
+------------------------
+
+-   [Slamhound](https://github.com/technomancy/slamhound) <span> | ★ 332, pushed 219 days ago | </span>
+-   [eastwood](https://github.com/jonase/eastwood) <span> | ★ 535, pushed 14 days ago | </span>
+-   [kibit](https://github.com/jonase/kibit) <span> | ★ 1021, pushed 5 days ago | </span>
+
+Science and Data Analysis
+-------------------------
+
+-   [Incanter](https://github.com/incanter/incanter) <span> | ★ 1725, pushed 72 days ago | </span>
+-   [Cascalog](http://cascalog.org/)
+-   [Onyx](https://github.com/onyx-platform/onyx) <span> | ★ 1200, pushed 1 days ago | </span>
+-   [Neanderthal](https://github.com/uncomplicate/neanderthal) <span> | ★ 145, pushed 10 days ago | </span>
+
+Machine Learning
+----------------
+
+-   [clj-ml](https://github.com/antoniogarrote/clj-ml) <span> | ★ 108, pushed 58 days ago | </span>
+-   [clj-bigml](https://github.com/bigmlcom/clj-bigml) <span> | ★ 44, pushed 30 days ago | </span>
+-   [Clatern](https://github.com/rinuboney/clatern) <span> | ★ 60, pushed 255 days ago | </span>
+-   [Deeplearning4j](https://github.com/deeplearning4j/deeplearning4j) <span> | ★ 2423, pushed 0 days ago | </span>
+-   [Enclog](https://github.com/jimpil/enclog) <span> | ★ 117, pushed 732 days ago | </span>
+-   [Infer](https://github.com/aria42/infer) <span> | ★ 146, pushed 113 days ago | </span>
+-   [k9](https://github.com/gigasquid/k9) <span> | ★ 74, pushed 425 days ago | </span>
+-   [Statistiker](https://github.com/clojurewerkz/statistiker) <span> | ★ 41, pushed 289 days ago | </span>
+-   [Synaptic](https://github.com/japonophile/synaptic) <span> | ★ 61, pushed 78 days ago | </span>
+
+Computer Vision
+---------------
+
+-   [clj-tesseract](https://github.com/antoniogarrote/clj-tesseract) <span> | ★ 33, pushed 1636 days ago | </span>
+-   [vision](http://nakkaya.com/vision.html)
+
+Natural Language Processing
+---------------------------
+
+-   [clojure-opennlp](https://github.com/dakrone/clojure-opennlp) <span> | ★ 545, pushed 336 days ago | </span>
+
+Editor Plugins
+--------------
+
+-   [CIDER](https://github.com/clojure-emacs/cider) <span> | ★ 1754, pushed 0 days ago | </span>
+-   [vim-fireplace](https://github.com/tpope/vim-fireplace) <span> | ★ 1056, pushed 2 days ago | </span>
+-   [vim-redl](https://github.com/dgrnbrg/vim-redl) <span> | ★ 95, pushed 421 days ago | </span>
+-   [vim-leiningen](https://github.com/tpope/vim-salve) <span> | ★ 121, pushed 183 days ago | </span>
+-   [rainbow\_parentheses.vim](https://github.com/junegunn/rainbow_parentheses.vim) <span> | ★ 103, pushed 169 days ago | </span>
+-   [Cursive (IntelliJ)](https://cursive-ide.com/)
+-   [Parinfer](http://shaunlebron.github.io/parinfer/)
+
+Literate Programming
+--------------------
+
+-   [marginalia](https://github.com/gdeer81/marginalia) <span> | ★ 592, pushed 35 days ago | </span>
+
+Miscellaneous
+-------------
+
+-   [clj-tuple](https://github.com/ztellman/clj-tuple) <span> | ★ 167, pushed 293 days ago | </span>
+-   [slingshot](https://github.com/scgilardi/slingshot) <span> | ★ 418, pushed 92 days ago | </span>
+
+Debugging
+---------
+
+-   [debugger](https://github.com/razum2um/debugger) <span> | ★ 0, pushed 677 days ago | </span>
+-   [debug-repl](https://github.com/GeorgeJahad/debug-repl) <span> | ★ 131, pushed 975 days ago | </span>
+-   [ritz](https://github.com/pallet/ritz) <span> | ★ 322, pushed 1070 days ago | </span>
+-   [redl](https://github.com/dgrnbrg/redl) <span> | ★ 29, pushed 627 days ago | </span>
+-   [limit-break](https://github.com/technomancy/limit-break) <span> | ★ 16, pushed 1355 days ago | </span>
+-   [spyscope](https://github.com/dgrnbrg/spyscope) <span> | ★ 328, pushed 148 days ago | </span>
+-   [aprint](https://github.com/razum2um/aprint) <span> | ★ 100, pushed 177 days ago | </span>
+-   [pretty](https://github.com/AvisoNovate/pretty) <span> | ★ 282, pushed 5 days ago | </span>
+-   [prone](https://github.com/magnars/prone) <span> | ★ 396, pushed 21 days ago | </span>
+-   [figwheel](https://github.com/bhauman/lein-figwheel) <span> | ★ 1534, pushed 0 days ago | </span>
+
+CI
+--
+
+-   [lambdacd](https://github.com/flosell/lambdacd) <span> | ★ 200, pushed 1 days ago | </span>
+
+Guides
+------
+
+-   [Clojure Distilled](http://yogthos.github.io/ClojureDistilled.html)
+-   [clojure-cookbook](https://github.com/clojure-cookbook/clojure-cookbook) <span> | ★ 1544, pushed 133 days ago | </span>
+-   [A Brief Beginner's Guide To Clojure](http://www.unexpected-vortices.com/clojure/brief-beginners-guide/index.html)
+-   [Clojure for the Brave and True](http://www.braveclojure.com/)
+-   [Clojure from the ground up](https://aphyr.com/tags/Clojure-from-the-ground-up)
+
+Websites
+--------
+
+-   [clojuredocs](http://clojuredocs.org)
+-   [crossclj](https://crossclj.info/)
+-   [clojure-doc](http://clojure-doc.org/)
+-   [Grimoire](http://conj.io/)
+-   [The Clojure Toolbox](http://www.clojure-toolbox.com/)
+-   [InstaREPL Online](http://web.clojurerepl.com/)
+-   [ZEEF/Clojure](https://clojure.zeef.com/vlad.bokov)
+-   [Try Clojure](http://www.tryclj.com/)
+
+Twitter
+-------
+
+-   [oss\_clj](https://twitter.com/oss_clj)
+
+Exercises
+---------
+
+-   [Clojure Koans](http://clojurekoans.com)
+-   [Wonderland Clojure Katas](https://github.com/gigasquid/wonderland-clojure-katas) <span> | ★ 413, pushed 6 days ago | </span>
+-   [Clojure Katas](http://clojurekatas.org)
+-   [4clojure](http://www.4clojure.com/)
+-   [exercism.io](http://exercism.io/languages/clojure)


### PR DESCRIPTION
I created a separate file that attach repo info (stars count, and last updated date) for each GitHub repositories included in README.md. It will help users quickly get the basic info of a certain repo.

I can update the file regularly (e.g. daily, weekly) or as needed.

View the file directly at:
https://github.com/chaconnewu/awesome-clojure/blob/master/awesome_clojure_with_repo_info.md
