### PR TITLE
Added Friboo to "RESTful API" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 
   * [Liberator](http://clojure-liberator.github.io/liberator/)
   * [compojure-api](https://github.com/metosin/compojure-api)
+  * [Friboo](https://github.com/zalando/friboo)
   * [yada](https://github.com/juxt/yada)
 
 ## Emails


### PR DESCRIPTION
Friboo is an open-source utility library to write microservices in Clojure, with support for Swagger and OAuth.