### PR TITLE
Added cats.match to "Pattern Matching" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@
   * [core.match](https://github.com/clojure/core.match)
   * [Verbal-Exprejon](https://github.com/GuillaumeBadi/Verbal-Exprejon)
   * [defun](https://github.com/killme2008/defun)
+  * [cats.match](https://github.com/zalando/cats.match)
 
 ## Async processing
 


### PR DESCRIPTION
cats.match (https://github.com/zalando/cats.match) offers pattern matching for the monads in the cats Clojure library.