### PR TITLE
Add link to Toucan

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@
   * [stch-library/sql](https://github.com/stch-library/sql)
   * [sqlingvo](https://github.com/r0man/sqlingvo)
   * [honeysql](https://github.com/jkk/honeysql)
-  * [Toucan](https://github.com/camsaul/toucan)
+  * [Toucan](https://github.com/metabase/toucan)
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
   * [stch-library/sql](https://github.com/stch-library/sql)
   * [sqlingvo](https://github.com/r0man/sqlingvo)
   * [honeysql](https://github.com/jkk/honeysql)
+  * [Toucan](https://github.com/camsaul/toucan)
 
 ## Security
 


### PR DESCRIPTION
Hey, first of all, awesome guide!

I'd like to add a link to [Toucan](https://github.com/metabase/toucan), a sort of lightweight-ORM for Clojure. It's based on the internal tools we've been using for two years or so at [Metabase](https://github.com/metabase/metabase) (another awesome product already on this list :sunglasses:).

Best,
Cam