### PR TITLE
Add "Clojure by Example" under Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ anylysis and visualization.*
   * [A Brief Beginner's Guide To Clojure](http://www.unexpected-vortices.com/clojure/brief-beginners-guide/index.html)
   * [Clojure for the Brave and True](http://www.braveclojure.com/)
   * [Clojure from the ground up](https://aphyr.com/tags/Clojure-from-the-ground-up)
+  * [Clojure by Example](https://kimh.github.io/clojure-by-example/)
 
 ## Websites
 


### PR DESCRIPTION
_Clojure by Example_ is a lean and mean primer for Clojure that focuses on code examples and has side-by-side explanations.