### PR TITLE
Remove link to Coils

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@
   * [Web Non-Framework](https://github.com/webnf/webnf)
   * [Luminus](http://www.luminusweb.net/)
   * [Joodo](https://github.com/slagyr/joodoweb)
-  * [Coils](https://github.com/zubairq/AppShare)
   * [Duct](https://github.com/weavejester/duct)
   * [Pedestal](https://github.com/pedestal/pedestal)
   * [Datsys](https://github.com/metasoarous/datsys)


### PR DESCRIPTION
The project appears to no longer exist and the link redirects to an unrelated repository