### PR TITLE
Add metabase/connection-pool to connection pools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@
 *Database connection pools*
 
   * [hikari-cp](https://github.com/tomekw/hikari-cp)
+  * [metabase/connection-pool](https://github.com/metabase/connection-pool)
 
 ## Structural Migrations
 


### PR DESCRIPTION
Simple wrapper around C3P0, arguably the most popular JDBC connection pooling lib.