### PR TITLE
Remove broken references from Websites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,6 @@ anylysis and visualization.*
   * [clojure-doc](http://clojure-doc.org/)
   * [The Clojure Toolbox](http://www.clojure-toolbox.com/)
   * [ZEEF/Clojure](https://clojure.zeef.com/vlad.bokov)
-  * [Try Clojure](http://www.tryclj.com/)
 
 ## Twitter
 

--- a/README.md
+++ b/README.md
@@ -525,10 +525,8 @@ anylysis and visualization.*
   * [Clojure](http://clojure.org/)
   * [Clojure Slack](http://clojurians.net/)
   * [clojuredocs](http://clojuredocs.org)
-  * [crossclj](https://crossclj.info/)
   * [clojure-doc](http://clojure-doc.org/)
   * [The Clojure Toolbox](http://www.clojure-toolbox.com/)
-  * [InstaREPL Online](http://web.clojurerepl.com/)
   * [ZEEF/Clojure](https://clojure.zeef.com/vlad.bokov)
   * [Try Clojure](http://www.tryclj.com/)
 


### PR DESCRIPTION
Looks like some references are broken in readme. I've removed few in Websites section:
* https://crossclj.info/ - refers to casino guide
* http://web.clojurerepl.com/ - looks like this resource doesn't exist anymore
* http://www.tryclj.com/ - looks like this resource doesn't exist anymore