### PR TITLE
Add clj-synapses library to ml section

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ anylysis and visualization.*
   * [Statistiker](https://github.com/clojurewerkz/statistiker)
   * [Synaptic](https://github.com/japonophile/synaptic)
   * [Infer](https://github.com/aria42/infer)
+  * [clj-synapses](https://cljdoc.org/d/org.clojars.mrdimosthenis/clj-synapses/)
 
 ## Computer Vision
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ anylysis and visualization.*
   * [Statistiker](https://github.com/clojurewerkz/statistiker)
   * [Synaptic](https://github.com/japonophile/synaptic)
   * [Infer](https://github.com/aria42/infer)
-  * [clj-synapses](https://cljdoc.org/d/org.clojars.mrdimosthenis/clj-synapses/)
+  * [clj-synapses](https://github.com/mrdimosthenis/clj-synapses)
 
 ## Computer Vision
 


### PR DESCRIPTION
clj-synapses is neural networks library for Clojure
* documentation: https://cljdoc.org/d/org.clojars.mrdimosthenis/clj-synapses/
* Synapses repo: https://github.com/mrdimosthenis/Synapses
* clj-synapses repo: https://github.com/mrdimosthenis/clj-synapses