### PR TITLE
feat: add protojure to the Protobuf/gRPC project's list

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@
 
   * [pronto](https://github.com/AppsFlyer/pronto)
   * [lein-protodeps](https://github.com/AppsFlyer/lein-protodeps)
+  * [protojure](https://github.com/metosin/protojure)
 
 ## Database Cli
 


### PR DESCRIPTION
protojure currently isn't listed in awesome-clojure. 